### PR TITLE
feat: Add customization options for fuzzy finder and package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ ex:
 abbr -a n -f _na
 ```
 
+## Customization
+You can customize the following options in your config.fish file:
+
+```fish
+# Set the fuzzy finder command to use (default: fzf)
+set -g NA_FUZZYFINDER fzf
+
+# Set the fuzzy finder options
+set -g NA_FUZZYFINDER_OPTIONS
+
+# Set your favorite package manager list. You can customize the order. (default: npm pnpm bun yarn deno)
+set -g NA_PACKAGE_MANAGER_LIST npm pnpm bun yarn deno
+```
+
 ## Usage
 Just type `n` (or your favorite abbr key) and hit space key, then the appropriate node/deno package manager command will be expanded.
 

--- a/functions/_na.fish
+++ b/functions/_na.fish
@@ -1,6 +1,21 @@
 # package manager detection logic is based on [kKaribash/ni.fish]
 # Original Source: https://github.com/Karibash/ni.fish/blob/main/functions/ni.fish
 
+# Set the fuzzy finder command to use
+if test -z "$NA_FUZZYFINDER"
+    set -g NA_FUZZYFINDER fzf
+end
+
+# Set the fuzzy finder options
+if test -z "$NA_FUZZYFINDER_OPTIONS"
+    set -g NA_FUZZYFINDER_OPTIONS
+end
+
+# Set your favorite package manager list. You can customize the order.
+if test -z "$NA_PACKAGE_MANAGER_LIST"
+    set -g NA_PACKAGE_MANAGER_LIST npm pnpm bun yarn deno
+end
+
 function _na
     _na_get_package_manager_name $PWD
 end
@@ -27,9 +42,8 @@ function _na_find_deno_json --argument-names path
     _na_find_up $path deno.json deno.jsonc
 end
 
-function _na_select_package_manager_with_fzf --argument-names path
-    set -l package_manager_names npm pnpm bun yarn deno
-    echo ( for i in $package_manager_names; echo $i; end  | fzf)
+function _na_select_package_manager_with_fuzzy_finder --argument-names path
+    echo ( for i in $NA_PACKAGE_MANAGER_LIST; echo $i; end  | $NA_FUZZYFINDER $NA_FUZZYFINDER_OPTIONS )
 end
 
 function _na_get_package_manager_name --argument-names path
@@ -73,5 +87,5 @@ function _na_get_package_manager_name --argument-names path
         return
     end
 
-    echo (_na_select_package_manager_with_fzf $path)
+    echo (_na_select_package_manager_with_fuzzy_finder $path)
 end


### PR DESCRIPTION
This commit introduces new customization options for the users. Users can now set their preferred fuzzy finder command and options via the `NA_FUZZYFINDER` and `NA_FUZZYFINDER_OPTIONS` variables respectively.

Additionally, users can now customize their favorite package manager list and their order via the `NA_PACKAGE_MANAGER_LIST` variable. The changes are reflected in both the README and the `_na.fish` function file.

fixes: #1