### PR TITLE
fix: correct the output message for unknown package manager

### DIFF
--- a/functions/_na.fish
+++ b/functions/_na.fish
@@ -64,7 +64,7 @@ function _na_get_package_manager_name --argument-names path
                 return
             end
 
-            echo "ni: Unknown packageManager: \"$package_manager_name\"" >&2
+            echo "na: Unknown packageManager: \"$package_manager_name\"" >&2
             return 1
         end
     end


### PR DESCRIPTION
This commit fixes the output message that is displayed when an unknown
package manager is encountered. Previously, the message incorrectly
started with "ni:". This has been corrected to "na:".
